### PR TITLE
perf: improve hash function based on fnv-1 and update benchmarks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.20"
+          go-version: "1.24"
       - name: Check out code
         uses: actions/checkout@v2
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -36,23 +36,23 @@ m.Delete(2)
 Looking at the benchmarks agains the standard Go map, this map should perform roughly 20-50% better depending on the conditions.
 
 ```
-cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkStore/intmap-8                 14422464                81.09 ns/op            0 B/op          0 allocs/op
-BenchmarkStore/sync-8                   10812642                93.62 ns/op            0 B/op          0 allocs/op
-BenchmarkStore/stdmap-8                 10179489               114.8 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/intmap-0%-8               10622955               108.6 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/sync-0%-8                  9956158               115.7 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/stdmap-0%-8               10334260               108.4 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/intmap-10%-8              10721809               105.1 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/sync-10%-8                 9463400               111.8 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/stdmap-10%-8              10433720               110.7 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/intmap-50%-8              12272485                88.29 ns/op            0 B/op          0 allocs/op
-BenchmarkLoad/sync-50%-8                11352820                91.41 ns/op            0 B/op          0 allocs/op
-BenchmarkLoad/stdmap-50%-8              10265517               111.1 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/intmap-90%-8              15370150                66.75 ns/op            0 B/op          0 allocs/op
-BenchmarkLoad/sync-90%-8                17687307                69.72 ns/op            0 B/op          0 allocs/op
-BenchmarkLoad/stdmap-90%-8              10236068               112.2 ns/op             0 B/op          0 allocs/op
-BenchmarkLoad/intmap-100%-8             20562958                58.48 ns/op            0 B/op          0 allocs/op
-BenchmarkLoad/sync-100%-8               18913777                62.92 ns/op            0 B/op          0 allocs/op
-BenchmarkLoad/stdmap-100%-8              9638715               109.7 ns/op             0 B/op          0 allocs/op
+cpu: 13th Gen Intel(R) Core(TM) i7-13700K
+BenchmarkStore/intmap-24         	144682518	        8.203 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStore/sync-24           	47746893	        24.78 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStore/stdmap-24         	65009140	        17.73 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-0%-24         	40558078	        28.98 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-0%-24           	36516896	        31.53 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-0%-24         	76847426	        15.57 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-10%-24        	40846196	        28.31 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-10%-24          	37622625	        31.21 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-10%-24        	69917145	        16.90 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-50%-24        	52405636	        21.62 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-50%-24          	44567251	        25.75 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-50%-24        	50478930	        23.68 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-90%-24        	140594277	        8.486 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-90%-24          	83630574	        14.40 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-90%-24        	69522844	        17.17 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-100%-24       	189147504	        6.271 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-100%-24         	88044195	        13.58 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-100%-24       	78736231	        15.12 ns/op	       0 B/op	       0 allocs/op
 ```

--- a/map.go
+++ b/map.go
@@ -283,7 +283,7 @@ func (m *Map) rehash() {
 
 // bucketOf calcultes the hash bucket for the integer key
 func bucketOf(key, mask uint32) uint32 {
-	h := key*0xdeece66d + 0xb
+	h := key*0x01000193 ^ 0x811c9dc5
 	return (h & mask) << 1
 }
 

--- a/map_test.go
+++ b/map_test.go
@@ -15,9 +15,9 @@ import (
 
 /*
 cpu: 13th Gen Intel(R) Core(TM) i7-13700K
-BenchmarkStore/intmap-24         	103890154	        10.93 ns/op	       0 B/op	       0 allocs/op
-BenchmarkStore/sync-24           	40663836	        26.10 ns/op	       0 B/op	       0 allocs/op
-BenchmarkStore/stdmap-24         	32448744	        36.67 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStore/intmap-24         	144682518	        8.203 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStore/sync-24           	47746893	        24.78 ns/op	       0 B/op	       0 allocs/op
+BenchmarkStore/stdmap-24         	65009140	        17.73 ns/op	       0 B/op	       0 allocs/op
 */
 func BenchmarkStore(b *testing.B) {
 	const count = 1000000
@@ -52,21 +52,21 @@ func BenchmarkStore(b *testing.B) {
 
 /*
 cpu: 13th Gen Intel(R) Core(TM) i7-13700K
-BenchmarkLoad/intmap-0%-24         	20124705	        59.05 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/sync-0%-24           	19219896	        62.01 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/stdmap-0%-24         	66543930	        16.92 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/intmap-10%-24        	20681667	        56.82 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/sync-10%-24          	19684521	        59.78 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/stdmap-10%-24        	53632722	        21.30 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/intmap-50%-24        	31344277	        37.56 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/sync-50%-24          	28165971	        41.10 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/stdmap-50%-24        	43359806	        26.15 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/intmap-90%-24        	93809362	        11.31 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/sync-90%-24          	61292348	        17.59 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/stdmap-90%-24        	38287116	        30.59 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/intmap-100%-24       	156096963	         7.426 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/sync-100%-24         	63665881	        16.59 ns/op	       0 B/op	       0 allocs/op
-BenchmarkLoad/stdmap-100%-24       	35932876	        32.91 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-0%-24         	39415726	        29.97 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-0%-24           	35625010	        32.50 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-0%-24         	80052386	        15.30 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-10%-24        	39902106	        28.79 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-10%-24          	36058449	        31.43 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-10%-24        	70262704	        17.18 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-50%-24        	51586498	        22.18 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-50%-24          	43119246	        26.08 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-50%-24        	40672450	        24.68 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-90%-24        	134907433	         8.708 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-90%-24          	72522013	        14.41 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-90%-24        	67797170	        18.24 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/intmap-100%-24       	181198509	         6.383 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/sync-100%-24         	88210225	        13.56 ns/op	       0 B/op	       0 allocs/op
+BenchmarkLoad/stdmap-100%-24       	78086083	        17.20 ns/op	       0 B/op	       0 allocs/op
 */
 func BenchmarkLoad(b *testing.B) {
 	const count = 1000000


### PR DESCRIPTION
This pull request includes updates to the hashing algorithm, benchmarking results, and performance benchmarks for the `Map` implementation. The changes improve the efficiency of the `Map` operations and provide updated benchmarks for comparison.

### Updates to hashing algorithm:
* [`map.go`](diffhunk://#diff-5ed7da7003773d8e0a4dca00d4fc08fc5582695eefe22a400db15edfd5aab840L286-R286): Updated the hash function in `bucketOf` to use the FNV-1a algorithm (`key*0x01000193 ^ 0x811c9dc5`), replacing the previous hash calculation. This change improves hash distribution and collision resistance.

### Updated benchmarking results:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R57): Replaced outdated benchmark results with new results using an updated CPU (`13th Gen Intel(R) Core(TM) i7-13700K`). The new benchmarks show improved performance across all scenarios for `intmap`, `sync`, and `stdmap`.

### Performance benchmarks in test file:
* [`map_test.go`](diffhunk://#diff-20f420b07153864bdb8f2b3fbaea5c8477fa6d1235495f367dbc8e697e587bbbL18-R20): Updated the benchmarking results in the comments for `BenchmarkStore` and `BenchmarkLoad` to reflect the improved performance of the `intmap` implementation. These updates align with the changes in the hash function and updated hardware. [[1]](diffhunk://#diff-20f420b07153864bdb8f2b3fbaea5c8477fa6d1235495f367dbc8e697e587bbbL18-R20) [[2]](diffhunk://#diff-20f420b07153864bdb8f2b3fbaea5c8477fa6d1235495f367dbc8e697e587bbbL55-R69)